### PR TITLE
Add avr/pgmspace.h stubs from Arduino Due

### DIFF
--- a/arduino-1.5.x/hardware/arduino/RBL_nRF51822/cores/arduino/Arduino.h
+++ b/arduino-1.5.x/hardware/arduino/RBL_nRF51822/cores/arduino/Arduino.h
@@ -24,6 +24,11 @@
 #include <string.h>
 #include <math.h>
 
+// some libraries and sketches depend on this
+// AVR stuff, assuming Arduino.h or WProgram.h
+// automatically includes it..
+#include <avr/pgmspace.h>
+
 #include "binary.h"
 
 #ifdef __cplusplus

--- a/arduino-1.5.x/hardware/arduino/RBL_nRF51822/cores/arduino/WString.h
+++ b/arduino-1.5.x/hardware/arduino/RBL_nRF51822/cores/arduino/WString.h
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <avr/pgmspace.h>
 
 // When compiling programs with this class, the following gcc parameters
 // dramatically increase performance and memory (RAM) efficiency, typically

--- a/arduino-1.5.x/hardware/arduino/RBL_nRF51822/cores/arduino/avr/pgmspace.h
+++ b/arduino-1.5.x/hardware/arduino/RBL_nRF51822/cores/arduino/avr/pgmspace.h
@@ -1,0 +1,44 @@
+#ifndef __PGMSPACE_H_
+#define __PGMSPACE_H_ 1
+
+#include <inttypes.h>
+
+#define PROGMEM
+#define PGM_P  const char *
+#define PSTR(str) (str)
+
+#define _SFR_BYTE(n) (n)
+
+typedef void prog_void;
+typedef char prog_char;
+typedef unsigned char prog_uchar;
+typedef int8_t prog_int8_t;
+typedef uint8_t prog_uint8_t;
+typedef int16_t prog_int16_t;
+typedef uint16_t prog_uint16_t;
+typedef int32_t prog_int32_t;
+typedef uint32_t prog_uint32_t;
+
+#define memcpy_P(dest, src, num) memcpy((dest), (src), (num))
+#define strcpy_P(dest, src) strcpy((dest), (src))
+#define strcat_P(dest, src) strcat((dest), (src))
+#define strcmp_P(a, b) strcmp((a), (b))
+#define strstr_P(a, b) strstr((a), (b))
+#define strlen_P(a) strlen((a))
+#define sprintf_P(s, f, ...) sprintf((s), (f), __VA_ARGS__)
+
+#define pgm_read_byte(addr) (*(const unsigned char *)(addr))
+#define pgm_read_word(addr) (*(const unsigned short *)(addr))
+#define pgm_read_dword(addr) (*(const unsigned long *)(addr))
+#define pgm_read_float(addr) (*(const float *)(addr))
+
+#define pgm_read_byte_near(addr) pgm_read_byte(addr)
+#define pgm_read_word_near(addr) pgm_read_word(addr)
+#define pgm_read_dword_near(addr) pgm_read_dword(addr)
+#define pgm_read_float_near(addr) pgm_read_float(addr)
+#define pgm_read_byte_far(addr) pgm_read_byte(addr)
+#define pgm_read_word_far(addr) pgm_read_word(addr)
+#define pgm_read_dword_far(addr) pgm_read_dword(addr)
+#define pgm_read_float_far(addr) pgm_read_float(addr)
+
+#endif


### PR DESCRIPTION
From: `hardware/arduino/sam/cores/arduino/avr/pgmspace.h`

Allows existing sketches that use [PROGMEM](http://arduino.cc/en/Reference/PROGMEM) to build without changes.
