### PR TITLE
Fix compile error with nrf_svc.h

### DIFF
--- a/arduino-1.5.x/hardware/arduino/RBL_nRF51822/nrf51822_SDK/Include/s110/nrf_svc.h
+++ b/arduino-1.5.x/hardware/arduino/RBL_nRF51822/nrf51822_SDK/Include/s110/nrf_svc.h
@@ -19,7 +19,7 @@ extern "C" {
   { \
     __asm( \
         "svc %0\n" \
-        "bx r14" : : "I" (number) : "r0" \
+        "bx r14" : : "I" ((uint16_t)number) : "r0" \
     ); \
   }
 #elif defined (__ICCARM__)
@@ -28,7 +28,7 @@ extern "C" {
 PRAGMA(swi_number = number) \
  __swi return_type signature;
 #else
-#define SVCALL(number, return_type, signature) return_type signature  
+#define SVCALL(number, return_type, signature) return_type signature
 #endif
 #endif  // SVCALL
 


### PR DESCRIPTION
I'm testing out unauthenticated security in [arduino-BLEPeripheral](https://github.com/sandeepmistry/arduino-BLEPeripheral), needed this patch to fix a compile error.

More info: https://devzone.nordicsemi.com/question/6950/upgrading-to-sdk-520-breaks-build/?answer=14073#post-id-14073