### PR TITLE
Various updates to S130 branch

### DIFF
--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/Arduino.h
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/Arduino.h
@@ -11,8 +11,6 @@
 #include <avr/pgmspace.h>
 
 #include "mbed.h"
-#include "BLE_API.h"
-#include "nRF51822_API.h"
 
 #include "wiring_constants.h"
 #include "wiring_digital.h"

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/Arduino.h
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/Arduino.h
@@ -34,7 +34,7 @@
 extern void setup( void ) ;
 extern void loop( void ) ;
 
-extern UARTClass Serial1;
+extern UARTClass Serial;
 
 #endif
 

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/BLE_API.h
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/BLE_API.h
@@ -25,7 +25,7 @@
 #include "ble/ServiceDiscovery.h"
 #include "ble/UUID.h"
 
-
+#include "nRF51822_API.h"
 
 // #include "BatteryService.h"
 // #include "DeviceInformationService.h"

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/mbed/api/mbed.h
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/mbed/api/mbed.h
@@ -41,7 +41,7 @@
 #include "AnalogIn.h"
 #include "AnalogOut.h"
 #include "PwmOut.h"
-#include "Serial.h"
+// #include "Serial.h" // this conflicts with the Arduino Serial, leave it out
 #include "SPI.h"
 #include "SPISlave.h"
 #include "I2C.h"

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/wiring_serial.cpp
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/wiring_serial.cpp
@@ -4,7 +4,7 @@
 #include "serial_api.h"
 
 Buffer 		rxbuffer;
-UARTClass 	Serial1;
+UARTClass 	Serial;
 
 void store(uint8_t c)
 {

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/BLE_Examples/examples/BLEController/BLEController.ino
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/BLE_Examples/examples/BLEController/BLEController.ino
@@ -25,6 +25,7 @@
     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 */
+#include <BLE_API.h>
 #include <Servo.h>
 #include "pin_inf.h"
 
@@ -41,8 +42,8 @@
 #define TXRX_BUF_LEN                     20
 
 BLE                                 	   ble;
-Ticker                                   ticker1, ticker2;   
-Servo                                    servos[MAX_SERVOS];       
+Ticker                                   ticker1, ticker2;
+Servo                                    servos[MAX_SERVOS];
 
 //for BLEController
 byte pins_mode[TOTAL_PINS];
@@ -75,8 +76,8 @@ GattService         uartService(service1_uuid, uartChars, sizeof(uartChars) / si
 
 void disconnectionCallBack(Gap::Handle_t handle, Gap::DisconnectionReason_t reason)
 {
-    Serial1.println("Disconnected!");
-    Serial1.println("Restarting the advertising process");
+    Serial.println("Disconnected!");
+    Serial.println("Restarting the advertising process");
     ble.startAdvertising();
 }
 
@@ -84,7 +85,7 @@ void reportPinDigitalData(byte pin)
 {
     byte state = digitalRead(pin);
     byte mode = pins_mode[pin];
-    byte buf[] = {'G', pin, mode, state};  
+    byte buf[] = {'G', pin, mode, state};
     ble.updateCharacteristicValue(characteristic2.getValueAttribute().getHandle(), buf, 4);
 }
 
@@ -92,7 +93,7 @@ void reportPinPWMData(byte pin)
 {
     byte value = pins_pwm[pin];
     byte mode = pins_mode[pin];
-    byte buf[] = {'G', pin, mode, value};         
+    byte buf[] = {'G', pin, mode, value};
     ble.updateCharacteristicValue(characteristic2.getValueAttribute().getHandle(), buf, 4);
 }
 
@@ -100,7 +101,7 @@ void reportPinServoData(byte pin)
 {
     byte value = pins_servo[pin];
     byte mode = pins_mode[pin];
-    byte buf[] = {'G', pin, mode, value};         
+    byte buf[] = {'G', pin, mode, value};
     ble.updateCharacteristicValue(characteristic2.getValueAttribute().getHandle(), buf, 4);
 }
 
@@ -108,19 +109,19 @@ void reportPinCapability(byte pin)
 {
     byte buf[] = {'P', pin, 0x00};
     byte pin_cap = 0;
-                      
+
     if (IS_PIN_DIGITAL(pin))
         pin_cap |= PIN_CAPABILITY_DIGITAL;
-              
+
     if (IS_PIN_ANALOG(pin))
         pin_cap |= PIN_CAPABILITY_ANALOG;
-  
+
     if (IS_PIN_PWM(pin))
         pin_cap |= PIN_CAPABILITY_PWM;
-  
+
     if (IS_PIN_SERVO(pin))
         pin_cap |= PIN_CAPABILITY_SERVO;
-  
+
     buf[2] = pin_cap;
     ble.updateCharacteristicValue(characteristic2.getValueAttribute().getHandle(), buf, 3);
 }
@@ -128,7 +129,7 @@ void reportPinCapability(byte pin)
 void sendCustomData(uint8_t *buf, uint8_t len)
 {
     uint8_t data[20] = "Z";
-    
+
     memcpy(&data[1], buf, len);
     ble.updateCharacteristicValue(characteristic2.getValueAttribute().getHandle(), data, len+1);
 }
@@ -145,24 +146,24 @@ byte reportDigitalInput()
             pin = 0;
         return 0;
     }
-    
+
     if (pins_mode[pin] == INPUT)
     {
         byte current_state = digitalRead(pin);
-              
+
         if (pins_state[pin] != current_state)
         {
             pins_state[pin] = current_state;
             byte buf[] = {'G', pin, INPUT, current_state};
             ble.updateCharacteristicValue(characteristic2.getValueAttribute().getHandle(), buf, 4);
-          
+
             report = 1;
         }
     }
     pin++;
     if (pin >= TOTAL_PINS)
         pin = 0;
-      
+
     return report;
 }
 
@@ -171,7 +172,7 @@ byte reportPinAnalogData()
 {
     static byte pin = 0;
     byte report = 0;
-  
+
     if (!IS_PIN_DIGITAL(pin))
     {
         pin++;
@@ -179,24 +180,24 @@ byte reportPinAnalogData()
             pin = 0;
         return 0;
     }
-    
+
     if (pins_mode[pin] == ANALOG)
     {
         uint16_t value = analogRead(pin);
         byte value_lo = value;
         byte value_hi = value>>8;
-        
+
         byte mode = pins_mode[pin];
         mode = (value_hi << 4) | mode;
-        
-        byte buf[] = {'G', pin, mode, value_lo};         
+
+        byte buf[] = {'G', pin, mode, value_lo};
         ble.updateCharacteristicValue(characteristic2.getValueAttribute().getHandle(), buf, 4);
     }
-    
+
     pin++;
     if (pin >= TOTAL_PINS)
         pin = 0;
-      
+
     return report;
 }
 
@@ -216,20 +217,20 @@ void m_status_check_handle()
 }
 
 void m_status_reback_handle()
-{   
+{
     uint32_t err_code = NRF_SUCCESS;
 
     if(reback_pin < TOTAL_PINS)
     {
-        reportPinCapability(reback_pin);     
+        reportPinCapability(reback_pin);
         if ( (pins_mode[reback_pin] == INPUT) || (pins_mode[reback_pin] == OUTPUT) )
             reportPinDigitalData(reback_pin);
         else if (pins_mode[reback_pin] == PWM)
             reportPinPWMData(reback_pin);
         else if (pins_mode[reback_pin] == SERVO)
-            reportPinServoData(reback_pin);     
-     
-        reback_pin++;     
+            reportPinServoData(reback_pin);
+
+        reback_pin++;
     }
     else
     {
@@ -249,14 +250,14 @@ void writtenHandle(const GattWriteCallbackParams *Handler)
 
     if (Handler->handle == characteristic1.getValueAttribute().getHandle()) {
         ble.readCharacteristicValue(characteristic1.getValueAttribute().getHandle(), buf, &bytesRead);
-        Serial1.print("bytesRead: ");
-        Serial1.println(bytesRead, HEX);
+        Serial.print("bytesRead: ");
+        Serial.println(bytesRead, HEX);
         //for(byte index=0; index<bytesRead; index++) {
-            Serial1.write(buf[0]);
-            Serial1.print(buf[1], DEC);
-            Serial1.print(buf[2], DEC);
+            Serial.write(buf[0]);
+            Serial.print(buf[1], DEC);
+            Serial.print(buf[2], DEC);
         //}
-        Serial1.println("");
+        Serial.println("");
         switch(buf[0])
         {
             case 'V': //query protocol version
@@ -269,13 +270,13 @@ void writtenHandle(const GattWriteCallbackParams *Handler)
             {
                 byte buf_tx[2] = {'C', TOTAL_PINS};
                 ble.updateCharacteristicValue(characteristic2.getValueAttribute().getHandle(), buf_tx, 2);
-                break;       
+                break;
             }
             case 'M': // query pin mode
             {
                 byte buf_tx[] = {'M', buf[1], pins_mode[ buf[2] ]};
                 ble.updateCharacteristicValue(characteristic2.getValueAttribute().getHandle(), buf_tx, 3);
-                break;                  
+                break;
             }
             case 'S': // set pin mode
             {
@@ -301,9 +302,9 @@ void writtenHandle(const GattWriteCallbackParams *Handler)
                     }
                     else if (mode == ANALOG)
                     {
-                        if (IS_PIN_ANALOG(pin)) 
+                        if (IS_PIN_ANALOG(pin))
                         {
-                            if (IS_PIN_DIGITAL(pin)) 
+                            if (IS_PIN_DIGITAL(pin))
                             {
                                 pinMode(PIN_TO_DIGITAL(pin), LOW);
                             }
@@ -338,11 +339,11 @@ void writtenHandle(const GattWriteCallbackParams *Handler)
                     reportPinPWMData(pin);
                 else if (mode == SERVO)
                     reportPinServoData(pin);
-             
+
                 break;
             }
             case 'G': // query pin data
-            {  
+            {
                 byte pin = buf[1];
                 reportPinDigitalData(pin);
                 break;
@@ -359,7 +360,7 @@ void writtenHandle(const GattWriteCallbackParams *Handler)
             {
                 byte pin = buf[1];
                 byte value = buf[2];
-                
+
                 analogWrite(PIN_TO_PWM(pin), value);
                 pins_pwm[pin] = value;
                 reportPinPWMData(pin);
@@ -373,13 +374,13 @@ void writtenHandle(const GattWriteCallbackParams *Handler)
                 if (IS_PIN_SERVO(pin))
                     servos[PIN_TO_SERVO(pin)].write(value);
                 pins_servo[pin] = value;
-                reportPinServoData(pin);       
-                break;         
+                reportPinServoData(pin);
+                break;
             }
             case 'A':// query all pin status
-            {    
+            {
                 reback_pin = 2;
-                ticker2.attach_us(m_status_reback_handle, 30000);  
+                ticker2.attach_us(m_status_reback_handle, 30000);
                 break;
             }
             case 'P':// query pin capability
@@ -391,18 +392,18 @@ void writtenHandle(const GattWriteCallbackParams *Handler)
             case 'Z':
             {
                 byte len = buf[1];
-                Serial1.println("->");
-                Serial1.print("Received: ");
-                Serial1.print(len);
-                Serial1.println(" byte(s)");
-                Serial1.print(" Hex: ");
+                Serial.println("->");
+                Serial.print("Received: ");
+                Serial.print(len);
+                Serial.println(" byte(s)");
+                Serial.print(" Hex: ");
                 for (int i=0;i<len;i++)
-                  Serial1.print(buf[i+2], HEX);
-                Serial1.println();
+                  Serial.print(buf[i+2], HEX);
+                Serial.println();
                 break;
-            }  
+            }
         }
-        buf_len = 0;          
+        buf_len = 0;
     }
     status_check_flag = 1;
 }
@@ -411,22 +412,22 @@ void writtenHandle(const GattWriteCallbackParams *Handler)
 
 void setup() {
     // put your setup code here, to run once
-    
-    Serial1.begin(9600);
+
+    Serial.begin(9600);
 
     ble.init();
     ble.onDisconnection(disconnectionCallBack);
     ble.onDataWritten(writtenHandle);
-      
+
     // setup adv_data and srp_data
     ble.accumulateAdvertisingPayload(GapAdvertisingData::BREDR_NOT_SUPPORTED);
     ble.accumulateAdvertisingPayload(GapAdvertisingData::SHORTENED_LOCAL_NAME,
                                      (const uint8_t *)"TXRX", sizeof("TXRX") - 1);
     ble.accumulateAdvertisingPayload(GapAdvertisingData::COMPLETE_LIST_128BIT_SERVICE_IDS,
                                      (const uint8_t *)uart_base_uuid_rev, sizeof(uart_base_uuid_rev));
-							  
+
     // set adv_type
-    ble.setAdvertisingType(GapAdvertisingParams::ADV_CONNECTABLE_UNDIRECTED);    
+    ble.setAdvertisingType(GapAdvertisingParams::ADV_CONNECTABLE_UNDIRECTED);
 	  // add service
     ble.addService(uartService);
     // set device name
@@ -446,7 +447,7 @@ void setup() {
         // Set pin to input with internal pull up
         pinMode(pin, INPUT);
         digitalWrite(pin, HIGH);
-    
+
         // Save pin mode and state
         pins_mode[pin] = INPUT;
         pins_state[pin] = LOW;
@@ -454,7 +455,7 @@ void setup() {
 
     ticker1.attach_us(m_status_check_handle, 100000);
 
-    Serial1.println("Advertising Start!");
+    Serial.println("Advertising Start!");
 }
 
 void loop() {

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/BLE_Examples/examples/BLE_CentralTest/BLE_CentralTest.ino
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/BLE_Examples/examples/BLE_CentralTest/BLE_CentralTest.ino
@@ -1,3 +1,4 @@
+#include <BLE_API.h>
 
 BLE           ble;
 
@@ -10,13 +11,13 @@ UUID service_uuid(0x180D);
 UUID chars_uuid1(0x2A37);
 UUID chars_uuid2(service1_chars2);
 UUID chars_uuid3(service1_chars3);
-    
+
 
 uint32_t ble_advdata_parser(uint8_t type, uint8_t advdata_len, uint8_t *p_advdata, uint8_t *len, uint8_t *p_field_data)
 {
     uint8_t index=0;
     uint8_t field_length, field_type;
-    
+
     while(index<advdata_len)
     {
         field_length = p_advdata[index];
@@ -34,79 +35,79 @@ uint32_t ble_advdata_parser(uint8_t type, uint8_t advdata_len, uint8_t *p_advdat
 
 void scanCallBack(const Gap::AdvertisementCallbackParams_t *params)
 {
-    Serial1.println("Scan CallBack ");
-    Serial1.print("PerrAddress: ");
+    Serial.println("Scan CallBack ");
+    Serial.print("PerrAddress: ");
     for(uint8_t index=0; index<6; index++)
     {
-        Serial1.print(params->peerAddr[index], HEX);  
-        Serial1.print(" ");
-    }   
-    Serial1.println(" ");  
-    
-    Serial1.print("The Rssi : ");
-    Serial1.println(params->rssi, DEC);
-    
-    Serial1.print("The adv_data : ");
-    Serial1.println((const char*)params->advertisingData);
-    
+        Serial.print(params->peerAddr[index], HEX);
+        Serial.print(" ");
+    }
+    Serial.println(" ");
+
+    Serial.print("The Rssi : ");
+    Serial.println(params->rssi, DEC);
+
+    Serial.print("The adv_data : ");
+    Serial.println((const char*)params->advertisingData);
+
     uint8_t len;
     uint8_t adv_name[31];
     if( NRF_SUCCESS == ble_advdata_parser(BLE_GAP_AD_TYPE_SHORT_LOCAL_NAME, params->advertisingDataLen, (uint8_t *)params->advertisingData, &len, adv_name) )
     {
-        Serial1.print("Short name len : ");
-        Serial1.println(len, DEC);
-        Serial1.print("Short name is : ");  
-        Serial1.println((const char*)adv_name);
-        
+        Serial.print("Short name len : ");
+        Serial.println(len, DEC);
+        Serial.print("Short name is : ");
+        Serial.println((const char*)adv_name);
+
         if( (len == 4) && (memcmp("TXRX", adv_name, len) == 0x00) )
         {
-            Serial1.println("Got device, stop scan ");    
+            Serial.println("Got device, stop scan ");
             ble.stopScan();
             ble.connect(params->peerAddr, Gap::ADDR_TYPE_RANDOM_STATIC, NULL, NULL);
         }
-        
+
     }
     else if( NRF_SUCCESS == ble_advdata_parser(BLE_GAP_AD_TYPE_COMPLETE_LOCAL_NAME, params->advertisingDataLen, (uint8_t *)params->advertisingData, &len, adv_name) )
     {
-        Serial1.print("Long name len : ");
-        Serial1.println(len, DEC);
-        Serial1.print("Long name is : ");  
-        Serial1.println((const char*)adv_name);
+        Serial.print("Long name len : ");
+        Serial.println(len, DEC);
+        Serial.print("Long name is : ");
+        Serial.println((const char*)adv_name);
 
         if( (len == 5) && (memcmp("HRM1", adv_name, len) == 0x00) )
         {
-             Serial1.println("Got device, stop scan ");    
+            Serial.println("Got device, stop scan ");
             ble.stopScan();
             ble.connect(params->peerAddr, Gap::ADDR_TYPE_RANDOM_STATIC, NULL, NULL);
         }
     }
-    Serial1.println(" ");   
+    Serial.println(" ");
 }
 
 void ServiceCallBack(const DiscoveredService *service)
 {
-    Serial1.println("Servuce Discovered............ ");   
-    Serial1.print("Short UUID : ");   
-    Serial1.println(service->getUUID().getShortUUID(), HEX);    
+    Serial.println("Servuce Discovered............ ");
+    Serial.print("Short UUID : ");
+    Serial.println(service->getUUID().getShortUUID(), HEX);
 }
 
 void CharacteristicCallBack(const DiscoveredCharacteristic *chars)
 {
-    Serial1.println("Characteristic Discovered........... \r\n");   
-    Serial1.print("properties_read        : ");
-    Serial1.println(chars->getProperties()._read, DEC);
-    Serial1.print("properties_writeWoResp : ");
-    Serial1.println(chars->getProperties()._writeWoResp, DEC);
-    Serial1.print("properties_write       : ");
-    Serial1.println(chars->getProperties()._write, DEC); 
-    Serial1.print("properties_notify      : ");    
-    Serial1.println(chars->getProperties()._notify, DEC);     
+    Serial.println("Characteristic Discovered........... \r\n");
+    Serial.print("properties_read        : ");
+    Serial.println(chars->getProperties()._read, DEC);
+    Serial.print("properties_writeWoResp : ");
+    Serial.println(chars->getProperties()._writeWoResp, DEC);
+    Serial.print("properties_write       : ");
+    Serial.println(chars->getProperties()._write, DEC);
+    Serial.print("properties_notify      : ");
+    Serial.println(chars->getProperties()._notify, DEC);
 
-    Serial1.print("valueHandle             : ");  
-    Serial1.println(chars->getValueHandle(), HEX);   
-    Serial1.print("CCCDHandle             : ");     
-    Serial1.println(chars->getCCCDHndle(), HEX);  
-    
+    Serial.print("valueHandle             : ");
+    Serial.println(chars->getValueHandle(), HEX);
+    Serial.print("CCCDHandle             : ");
+    Serial.println(chars->getCCCDHndle(), HEX);
+
     uint16_t value = 0x0001;
     //ble.gattClient().read(chars->getConnHandle(), chars->getValueHandle(), 0);
     //ble.gattClient().write(GattClient::GATT_OP_WRITE_CMD,chars->getConnHandle(),chars->getValueHandle(),2,(uint8_t *)&value);
@@ -116,71 +117,71 @@ void CharacteristicCallBack(const DiscoveredCharacteristic *chars)
 // GAP call back handle
 void connectionCallBack( const Gap::ConnectionCallbackParams_t *params )
 {
-    Serial1.print("GAP_EVT_CONNECTED");    
-    Serial1.print("The conn handle : ");
-    Serial1.println(params->handle, HEX);  
-  
-    Serial1.print("  The peerAddr : ");
+    Serial.print("GAP_EVT_CONNECTED");
+    Serial.print("The conn handle : ");
+    Serial.println(params->handle, HEX);
+
+    Serial.print("  The peerAddr : ");
     for(uint8_t index=0; index<6; index++)
     {
-       Serial1.print(params->peerAddr[index], HEX);
-       Serial1.print(" ");  
+       Serial.print(params->peerAddr[index], HEX);
+       Serial.print(" ");
     }
-    Serial1.println(" ");  
-    
+    Serial.println(" ");
+
     ble.gattClient().launchServiceDiscovery(params->handle, ServiceCallBack, CharacteristicCallBack, service_uuid, chars_uuid1);
 }
 
 void disconnectionCallBack(Gap::Handle_t handle, Gap::DisconnectionReason_t reason)
 {
-   Serial1.println("Disconnected ");
+   Serial.println("Disconnected ");
 }
 
 void discoveryTermination(Gap::Handle_t connectionHandle)
 {
-    Serial1.println("discoveryTermination............ ");    
+    Serial.println("discoveryTermination............ ");
 }
 
 void onDataWrite(const GattWriteCallbackParams *params)
 {
-    Serial1.println("GattClient write call back ");    
+    Serial.println("GattClient write call back ");
 }
 
 void onDataRead(const GattReadCallbackParams *params)
 {
-    Serial1.println("GattClient read call back ");      
-    Serial1.print("The handle : ");
-    Serial1.println(params->handle, HEX);  
-    Serial1.print("The offset : ");
-    Serial1.println(params->offset, DEC); 
-    Serial1.print("The len : ");
-    Serial1.println(params->len, DEC); 
-    Serial1.print("The data : ");
+    Serial.println("GattClient read call back ");
+    Serial.print("The handle : ");
+    Serial.println(params->handle, HEX);
+    Serial.print("The offset : ");
+    Serial.println(params->offset, DEC);
+    Serial.print("The len : ");
+    Serial.println(params->len, DEC);
+    Serial.print("The data : ");
     for(uint8_t index=0; index<params->len; index++)
     {
-        Serial1.print( params->data[index], HEX);    
+        Serial.print( params->data[index], HEX);
     }
-    Serial1.println("");
+    Serial.println("");
 }
 
 void hvxCallBack(const GattHVXCallbackParams *params)
 {
-    Serial1.println("GattClient notify call back \r\n");  
-    Serial1.print("The len : ");
-    Serial1.println(params->len, DEC); 
+    Serial.println("GattClient notify call back \r\n");
+    Serial.print("The len : ");
+    Serial.println(params->len, DEC);
     for(unsigned char index=0; index<params->len; index++)
     {
-        Serial1.print(params->data[index], HEX);  
+        Serial.print(params->data[index], HEX);
     }
-    Serial1.println("");
+    Serial.println("");
 }
 
 int main(void)
 {
-    Serial1.begin(9600);
+    Serial.begin(9600);
     wait(8);
-    Serial1.println("BLE Scan ");
-    
+    Serial.println("BLE Scan ");
+
     ble.init();
     ble.onConnection(connectionCallBack);
     ble.onDisconnection(disconnectionCallBack);
@@ -188,12 +189,12 @@ int main(void)
     ble.gattClient().onHVX(hvxCallBack);
     ble.gattClient().onDataWrite(onDataWrite);
     ble.gattClient().onDataRead(onDataRead);
-    
+
     ble.startScan(scanCallBack);
-    
+
 
     while(1)
     {
-          
+
     }
 }

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/BLE_Examples/examples/BLE_ScanReport/BLE_ScanReport.ino
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/BLE_Examples/examples/BLE_ScanReport/BLE_ScanReport.ino
@@ -1,11 +1,12 @@
+#include <BLE_API.h>
 
 BLE           ble;
- 
+
 uint32_t ble_advdata_decode(uint8_t type, uint8_t advdata_len, uint8_t *p_advdata, uint8_t *len, uint8_t *p_field_data)
 {
     uint8_t index=0;
     uint8_t field_length, field_type;
-    
+
     while(index<advdata_len)
     {
         field_length = p_advdata[index];
@@ -23,50 +24,50 @@ uint32_t ble_advdata_decode(uint8_t type, uint8_t advdata_len, uint8_t *p_advdat
 
 void scanCallBack(const Gap::AdvertisementCallbackParams_t *params)
 {
-     Serial1.println("Scan Device CallBack Handle ");
-     
-     Serial1.print("  The peerAddr : ");
+     Serial.println("Scan Device CallBack Handle ");
+
+     Serial.print("  The peerAddr : ");
      for(uint8_t index=0; index<6; index++)
      {
-         Serial1.print(params->peerAddr[index], HEX);
-         Serial1.print(" ");  
+         Serial.print(params->peerAddr[index], HEX);
+         Serial.print(" ");
      }
-     Serial1.println(" ");  
-     
-     Serial1.print("  The Rssi : ");
-     Serial1.println(params->rssi, DEC);
-     
+     Serial.println(" ");
+
+     Serial.print("  The Rssi : ");
+     Serial.println(params->rssi, DEC);
+
      uint8_t len;
      uint8_t adv_name[31];
      if( NRF_SUCCESS == ble_advdata_decode(BLE_GAP_AD_TYPE_SHORT_LOCAL_NAME, params->advertisingDataLen, (uint8_t *)params->advertisingData, &len, adv_name) )
      {
-         Serial1.print("  The length of Short Local Name : ");
-         Serial1.println(len, HEX);
-         Serial1.print("  The Short Local Name is        : ");
-         Serial1.println((const char *)adv_name);
+         Serial.print("  The length of Short Local Name : ");
+         Serial.println(len, HEX);
+         Serial.print("  The Short Local Name is        : ");
+         Serial.println((const char *)adv_name);
      }
      else if( NRF_SUCCESS == ble_advdata_decode(BLE_GAP_AD_TYPE_COMPLETE_LOCAL_NAME, params->advertisingDataLen, (uint8_t *)params->advertisingData, &len, adv_name) )
      {
-         Serial1.print("  The length of Complete Local Name : ");
-         Serial1.println(len, HEX);
-         Serial1.print("  The Complete Local Name is        : ");
-         Serial1.println((const char *)adv_name);
+         Serial.print("  The length of Complete Local Name : ");
+         Serial.println(len, HEX);
+         Serial.print("  The Complete Local Name is        : ");
+         Serial.println((const char *)adv_name);
      }
-     Serial1.println(" ");  
-     Serial1.println(" ");  
+     Serial.println(" ");
+     Serial.println(" ");
 }
- 
-void setup() 
+
+void setup()
 {
     // put your setup code here, to run once:
-    Serial1.begin(9600);
-    Serial1.println("Start...");
+    Serial.begin(9600);
+    Serial.println("Start...");
     ble.init();
     //Note : take care of scheduler, prevent ram leak.See projectconfig.h
     ble.startScan(scanCallBack);
 }
 
-void loop() 
+void loop()
 {
     // put your main code here, to run repeatedly:
     ble.waitForEvent();

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/BLE_Examples/examples/BLE_Serial/BLE_Serial.ino
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/BLE_Examples/examples/BLE_Serial/BLE_Serial.ino
@@ -1,9 +1,9 @@
-
+#include <BLE_API.h>
 
 #define TXRX_BUF_LEN                      20
 
-BLE                                 	    ble;
-Timeout                                   timeout;                
+BLE                                       ble;
+Timeout                                   timeout;
 
 static uint8_t rx_buf[TXRX_BUF_LEN];
 static uint8_t rx_buf_num;
@@ -40,58 +40,58 @@ void writtenHandle(const GattWriteCallbackParams *Handler)
     if (Handler->handle == characteristic1.getValueAttribute().getHandle()) {
         ble.readCharacteristicValue(characteristic1.getValueAttribute().getHandle(), buf, &bytesRead);
         for(byte index=0; index<bytesRead; index++) {
-            Serial1.write(buf[index]);
+            Serial.write(buf[index]);
         }
     }
 }
 
 void m_uart_rx_handle()
 {   //update characteristic data
-    ble.updateCharacteristicValue(characteristic2.getValueAttribute().getHandle(), rx_buf, rx_buf_num);   
+    ble.updateCharacteristicValue(characteristic2.getValueAttribute().getHandle(), rx_buf, rx_buf_num);
     memset(rx_buf, 0x00,20);
     rx_state = 0;
 }
 
 void uart_handle(uint32_t id, SerialIrq event)
-{   /* Serial1 rx IRQ */
-    if(event == RxIrq) {   
-        if (rx_state == 0) {  
+{   /* Serial rx IRQ */
+    if(event == RxIrq) {
+        if (rx_state == 0) {
             rx_state = 1;
             timeout.attach_us(m_uart_rx_handle, 100000);
             rx_buf_num=0;
         }
-        while(Serial1.available()) {
+        while(Serial.available()) {
             if(rx_buf_num < 20) {
-                rx_buf[rx_buf_num] = Serial1.read();
+                rx_buf[rx_buf_num] = Serial.read();
                 rx_buf_num++;
             }
             else {
-                Serial1.read();
+                Serial.read();
             }
-        }   
+        }
     }
 }
 
 void setup() {
-  
+
     // put your setup code here, to run once
-    Serial1.begin(9600);
-    Serial1.attach(uart_handle);
+    Serial.begin(9600);
+    Serial.attach(uart_handle);
 
     ble.init();
     ble.onDisconnection(disconnectionCallBack);
     ble.onDataWritten(writtenHandle);
-      
+
     // setup adv_data and srp_data
     ble.accumulateAdvertisingPayload(GapAdvertisingData::BREDR_NOT_SUPPORTED);
     ble.accumulateAdvertisingPayload(GapAdvertisingData::SHORTENED_LOCAL_NAME,
                                      (const uint8_t *)"TXRX", sizeof("TXRX") - 1);
     ble.accumulateAdvertisingPayload(GapAdvertisingData::COMPLETE_LIST_128BIT_SERVICE_IDS,
                                      (const uint8_t *)uart_base_uuid_rev, sizeof(uart_base_uuid_rev));
-							  
+
     // set adv_type
-    ble.setAdvertisingType(GapAdvertisingParams::ADV_CONNECTABLE_UNDIRECTED);    
-	  // add service
+    ble.setAdvertisingType(GapAdvertisingParams::ADV_CONNECTABLE_UNDIRECTED);
+    // add service
     ble.addService(uartService);
     // set device name
     ble.setDeviceName((const uint8_t *)"BLE Serial");

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/BLE_Examples/examples/BLE_SimplePeripheral/BLE_SimplePeripheral.ino
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/BLE_Examples/examples/BLE_SimplePeripheral/BLE_SimplePeripheral.ino
@@ -1,4 +1,4 @@
-
+#include <BLE_API.h>
 
 #define TXRX_BUF_LEN                      20
 
@@ -31,8 +31,8 @@ GattService         uartService(service1_uuid, uartChars, sizeof(uartChars) / si
 
 void disconnectionCallBack(Gap::Handle_t handle, Gap::DisconnectionReason_t reason)
 {
-    Serial1.println("Disconnected ");
-    Serial1.println("Restart advertising ");
+    Serial.println("Disconnected ");
+    Serial.println("Restart advertising ");
     ble.startAdvertising();
 }
 
@@ -42,53 +42,53 @@ void writtenHandle(const GattWriteCallbackParams *Handler)
     uint8_t buf[TXRX_BUF_LEN];
     uint16_t bytesRead, index;
 
-    Serial1.println("Write Handle : ");
+    Serial.println("Write Handle : ");
     if (Handler->handle == characteristic1.getValueAttribute().getHandle())
     {
         ble.readCharacteristicValue(characteristic1.getValueAttribute().getHandle(), buf, &bytesRead);
         for(byte index=0; index<bytesRead; index++)
         {
-            Serial1.print(buf[index], HEX);
+            Serial.print(buf[index], HEX);
         }
-        Serial1.println(" ");
+        Serial.println(" ");
     }
 }
 
 // Task handle
 void m_1s_handle(void)
 {
-    Serial1.println("1s Loop ");
+    Serial.println("1s Loop ");
     value++;
     ble.updateCharacteristicValue(characteristic3.getValueAttribute().getHandle(), (uint8_t *)&value, 2);
 }
 
 void setup() {
-  
+
     ticker.attach(m_1s_handle, 1);
     // put your setup code here, to run once
-    Serial1.begin(9600);
+    Serial.begin(9600);
     pinMode(D13, OUTPUT);
-    
-    Serial1.println("Start ");
+
+    Serial.println("Start ");
     ble.init();
     ble.onDisconnection(disconnectionCallBack);
     ble.onDataWritten(writtenHandle);
-      
+
     // setup adv_data and srp_data
     ble.accumulateAdvertisingPayload(GapAdvertisingData::BREDR_NOT_SUPPORTED);
     ble.accumulateAdvertisingPayload(GapAdvertisingData::SHORTENED_LOCAL_NAME,
                                      (const uint8_t *)"TXRX", sizeof("TXRX") - 1);
     ble.accumulateAdvertisingPayload(GapAdvertisingData::COMPLETE_LIST_128BIT_SERVICE_IDS,
                                      (const uint8_t *)uart_base_uuid_rev, sizeof(uart_base_uuid_rev));
-                                     
-    ble.accumulateScanResponse(GapAdvertisingData::SHORTENED_LOCAL_NAME, 
-                              (const uint8_t *)"hello", sizeof("hello") - 1);                        
-    ble.accumulateScanResponse(GapAdvertisingData::COMPLETE_LIST_128BIT_SERVICE_IDS, 
-                              (const uint8_t *)uart_base_uuid_rev, sizeof(uart_base_uuid_rev));     
-							  
+
+    ble.accumulateScanResponse(GapAdvertisingData::SHORTENED_LOCAL_NAME,
+                              (const uint8_t *)"hello", sizeof("hello") - 1);
+    ble.accumulateScanResponse(GapAdvertisingData::COMPLETE_LIST_128BIT_SERVICE_IDS,
+                              (const uint8_t *)uart_base_uuid_rev, sizeof(uart_base_uuid_rev));
+
     // set adv_type
-    ble.setAdvertisingType(GapAdvertisingParams::ADV_CONNECTABLE_UNDIRECTED);    
-	// add service
+    ble.setAdvertisingType(GapAdvertisingParams::ADV_CONNECTABLE_UNDIRECTED);
+    // add service
     ble.addService(uartService);
     // set device name
     ble.setDeviceName((const uint8_t *)"Serial UART");
@@ -100,11 +100,11 @@ void setup() {
     // set adv_timeout, in seconds
     ble.setAdvertisingTimeout(0);
     // ger BLE stack version
-    Serial1.println( ble.getVersion() );
+    Serial.println( ble.getVersion() );
     // start advertising
     ble.startAdvertising();
 
-    Serial1.println("start advertising ");
+    Serial.println("start advertising ");
 }
 
 void loop() {

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/BLE_Examples/examples/SimpleChat/SimpleChat.ino
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/BLE_Examples/examples/SimpleChat/SimpleChat.ino
@@ -1,9 +1,9 @@
-
+#include <BLE_API.h>
 
 #define TXRX_BUF_LEN                      20
 
 BLE                                 	    ble;
-Timeout                                   timeout;                
+Timeout                                   timeout;
 
 static uint8_t rx_buf[TXRX_BUF_LEN];
 static uint8_t rx_buf_num;
@@ -29,8 +29,8 @@ GattService         uartService(service1_uuid, uartChars, sizeof(uartChars) / si
 
 void disconnectionCallBack(Gap::Handle_t handle, Gap::DisconnectionReason_t reason)
 {
-    Serial1.println("Disconnected!");
-    Serial1.println("Restarting the advertising process");
+    Serial.println("Disconnected!");
+    Serial.println("Restarting the advertising process");
     ble.startAdvertising();
 }
 
@@ -39,65 +39,65 @@ void writtenHandle(const GattWriteCallbackParams *Handler)
     uint8_t buf[TXRX_BUF_LEN];
     uint16_t bytesRead, index;
 
-    Serial1.println("onDataWritten : ");
+    Serial.println("onDataWritten : ");
     if (Handler->handle == characteristic1.getValueAttribute().getHandle()) {
         ble.readCharacteristicValue(characteristic1.getValueAttribute().getHandle(), buf, &bytesRead);
-        Serial1.print("bytesRead: ");
-        Serial1.println(bytesRead, HEX);
+        Serial.print("bytesRead: ");
+        Serial.println(bytesRead, HEX);
         for(byte index=0; index<bytesRead; index++) {
-            Serial1.write(buf[index]);
+            Serial.write(buf[index]);
         }
-        Serial1.println("");
+        Serial.println("");
     }
 }
 
 void m_uart_rx_handle()
 {   //update characteristic data
-    ble.updateCharacteristicValue(characteristic2.getValueAttribute().getHandle(), rx_buf, rx_buf_num);   
+    ble.updateCharacteristicValue(characteristic2.getValueAttribute().getHandle(), rx_buf, rx_buf_num);
     memset(rx_buf, 0x00,20);
     rx_state = 0;
 }
 
 void uart_handle(uint32_t id, SerialIrq event)
-{   /* Serial1 rx IRQ */
-    if(event == RxIrq) {   
-        if (rx_state == 0) {  
+{   /* Serial rx IRQ */
+    if(event == RxIrq) {
+        if (rx_state == 0) {
             rx_state = 1;
             timeout.attach_us(m_uart_rx_handle, 100000);
             rx_buf_num=0;
         }
-        while(Serial1.available()) {
+        while(Serial.available()) {
             if(rx_buf_num < 20) {
-                rx_buf[rx_buf_num] = Serial1.read();
+                rx_buf[rx_buf_num] = Serial.read();
                 rx_buf_num++;
             }
             else {
-                Serial1.read();
+                Serial.read();
             }
-        }   
+        }
     }
 }
 
 void setup() {
-  
+
     // put your setup code here, to run once
-    Serial1.begin(9600);
-    Serial1.attach(uart_handle);
+    Serial.begin(9600);
+    Serial.attach(uart_handle);
 
     ble.init();
     ble.onDisconnection(disconnectionCallBack);
     ble.onDataWritten(writtenHandle);
-      
+
     // setup adv_data and srp_data
     ble.accumulateAdvertisingPayload(GapAdvertisingData::BREDR_NOT_SUPPORTED);
     ble.accumulateAdvertisingPayload(GapAdvertisingData::SHORTENED_LOCAL_NAME,
                                      (const uint8_t *)"TXRX", sizeof("TXRX") - 1);
     ble.accumulateAdvertisingPayload(GapAdvertisingData::COMPLETE_LIST_128BIT_SERVICE_IDS,
                                      (const uint8_t *)uart_base_uuid_rev, sizeof(uart_base_uuid_rev));
-							  
+
     // set adv_type
-    ble.setAdvertisingType(GapAdvertisingParams::ADV_CONNECTABLE_UNDIRECTED);    
-	  // add service
+    ble.setAdvertisingType(GapAdvertisingParams::ADV_CONNECTABLE_UNDIRECTED);
+    // add service
     ble.addService(uartService);
     // set device name
     ble.setDeviceName((const uint8_t *)"Simple Chat");
@@ -110,7 +110,7 @@ void setup() {
     // start advertising
     ble.startAdvertising();
 
-    Serial1.println("Advertising Start!");
+    Serial.println("Advertising Start!");
 }
 
 void loop() {

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/SPI_Master/examples/SPI_Flash_45DB021D/SPI_Flash_45DB021D.ino
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/SPI_Master/examples/SPI_Flash_45DB021D/SPI_Flash_45DB021D.ino
@@ -33,7 +33,7 @@ Flash chip: 45DB021D
 #include <SPI_Master.h>
 
 void Flash_Buff_WriteBytes(uint16_t addr, uint8_t *pbuf, uint16_t len)
-{    
+{
     uint16_t index;
 
     digitalWrite(10, LOW);
@@ -57,20 +57,20 @@ void Flash_Buff_ReadBytes(uint16_t addr, uint8_t *pbuf, uint16_t len)
     uint16_t index;
 
     digitalWrite(10, LOW);
-    delayMicroseconds(200); 
+    delayMicroseconds(200);
 
     SPI_Master.transfer(0xD1);
-    SPI_Master.transfer(0x00);  
+    SPI_Master.transfer(0x00);
     SPI_Master.transfer( (uint8_t)(addr>>8) );
-    SPI_Master.transfer( (uint8_t)addr );    
+    SPI_Master.transfer( (uint8_t)addr );
     for(index=0; index<len; index++)
     {
         *pbuf = SPI_Master.transfer(0x00);
         pbuf++;
-    }   
+    }
 
     delayMicroseconds(200);
-    digitalWrite(10, HIGH);   
+    digitalWrite(10, HIGH);
 }
 
 uint8_t i;
@@ -81,9 +81,9 @@ uint8_t rd_buf[7];
 void setup() {
 
     pinMode(D13, OUTPUT);
-    Serial1.begin(9600);  
-    Serial1.println("SPI Start ");
-    
+    Serial.begin(9600);
+    Serial.println("SPI Start ");
+
     pinMode(10, OUTPUT);
     digitalWrite(10, HIGH);
     //SPI_Master.begin();
@@ -104,7 +104,7 @@ void loop() {
     memset(rd_buf, 0x00, 7);
     Flash_Buff_ReadBytes(0, rd_buf, 7);
     for(i=0; i<7; i++)
-      Serial1.write(rd_buf[i]);
+      Serial.write(rd_buf[i]);
 }
 
 

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/Wire/examples/AT24C512_Demo/AT24C512_Demo.ino
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/Wire/examples/AT24C512_Demo/AT24C512_Demo.ino
@@ -42,12 +42,12 @@ void AT24C512_WriteBytes(uint16_t addr, uint8_t *pbuf, uint16_t len)
 }
 
 void AT24C512_ReadBytes(uint16_t addr, uint8_t *pbuf, uint16_t len)
-{    
+{
     Wire.beginTransmission(DEV_ADDR);
     Wire.write((uint8_t)addr>>8);
-    Wire.write((uint8_t)addr);    
+    Wire.write((uint8_t)addr);
     Wire.endTransmission();
-    
+
     Wire.requestFrom(DEV_ADDR,len);
     while( Wire.available() > 0 )
     {
@@ -59,11 +59,11 @@ void AT24C512_ReadBytes(uint16_t addr, uint8_t *pbuf, uint16_t len)
 void setup() {
     // put your setup code here, to run once:
     pinMode(D13, OUTPUT);
-    Serial1.begin(115200);
-    Serial1.println("Wire demo start ");   
+    Serial.begin(115200);
+    Serial.println("Wire demo start ");
 
     Wire.begin();
-    Serial1.println("Wire demo start");
+    Serial.println("Wire demo start");
     AT24C512_WriteBytes(0, wt_data, 10);
 }
 
@@ -75,9 +75,9 @@ void loop() {
     delay(500);
 
     AT24C512_ReadBytes(0, rd_data, 10);
-    Serial1.println("Read data from AT24C512: ");
-    Serial1.write(rd_data, 10);
-    Serial1.print("\r\n");
+    Serial.println("Read data from AT24C512: ");
+    Serial.write(rd_data, 10);
+    Serial.print("\r\n");
 }
 
 

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/Wire/examples/master_read/master_read.ino
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/Wire/examples/master_read/master_read.ino
@@ -40,23 +40,23 @@
 
 #include <Wire.h>
 
-void setup() 
+void setup()
 {
     // put your setup code here, to run once:
-    Serial1.begin(115200);
+    Serial.begin(115200);
     Wire.begin();
-    Serial1.println("master read...");
+    Serial.println("master read...");
 }
 
-void loop() 
+void loop()
 {
-    // put your main code here, to run repeatedly: 
+    // put your main code here, to run repeatedly:
     Wire.requestFrom(0x02,6);
-    
+
     while( Wire.available() > 0 )
     {
         uint8_t c = Wire.read();
-        Serial1.write(c);
+        Serial.write(c);
     }
     delay(1000);
 }

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/Wire/examples/master_write/master_write.ino
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/Wire/examples/master_write/master_write.ino
@@ -38,26 +38,26 @@
 
 #include <Wire.h>
 
-void setup() 
+void setup()
 {
     // put your setup code here, to run once:
-    Serial1.begin(115200);
+    Serial.begin(115200);
     Wire.begin();
-    Serial1.println("master write...");
+    Serial.println("master write...");
 }
 
 byte x = 0;
 
-void loop() 
+void loop()
 {
-    // put your main code here, to run repeatedly: 
-    Serial1.println("master send begin: ");
-    
+    // put your main code here, to run repeatedly:
+    Serial.println("master send begin: ");
+
     Wire.beginTransmission(0x04);
     Wire.write("x is");
     Wire.write(x);
     Wire.endTransmission();
-    
+
     x++;
     delay(1000);
 }

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/nRF_Examples/examples/External_Interrupter/External_Interrupter.ino
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/nRF_Examples/examples/External_Interrupter/External_Interrupter.ino
@@ -27,17 +27,17 @@
 
 void handle_irq1(void)
 {
-    Serial1.println(" Handle1  ");
+    Serial.println(" Handle1  ");
 }
 
 void handle_irq2(void)
 {
-    Serial1.println(" Handle2  ");
+    Serial.println(" Handle2  ");
 }
 
 void handle_irq3(void)
 {
-    Serial1.println(" Handle3  ");
+    Serial.println(" Handle3  ");
 }
 
 void setup() {
@@ -45,10 +45,10 @@ void setup() {
     attachInterrupt(D6, handle_irq1, RISING);
     attachInterrupt(D7, handle_irq2, FALLING);
     attachInterrupt(D8, handle_irq3, CHANGE);
-    
+
     pinMode(D13, OUTPUT);
-    Serial1.begin(9600);  
-    Serial1.println("External Interrupter Demo ");
+    Serial.begin(9600);
+    Serial.println("External Interrupter Demo ");
 }
 
 void loop() {

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/nRF_Examples/examples/Serial_IRQ_Handle/Serial_IRQ_Handle.ino
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/nRF_Examples/examples/Serial_IRQ_Handle/Serial_IRQ_Handle.ino
@@ -26,22 +26,22 @@
 */
 
 void uart_handle(uint32_t id, SerialIrq event)
-{   /* Serial1 rx IRQ */
+{   /* Serial rx IRQ */
     if(event == RxIrq)
-    {   
-        if(Serial1.available())
+    {
+        if(Serial.available())
         {
-            Serial1.write(Serial1.read()); 
-        }      
+            Serial.write(Serial.read());
+        }
     }
 }
 
 void setup() {
-  
+
     pinMode(D13, OUTPUT);
-    Serial1.begin(9600);  
-    Serial1.attach(uart_handle);
-    Serial1.println("Serial1 IRQ Handle ");
+    Serial.begin(9600);
+    Serial.attach(uart_handle);
+    Serial.println("Serial IRQ Handle ");
 }
 
 void loop() {

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/nRF_Examples/examples/Ticker_Task/Ticker_Task.ino
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/nRF_Examples/examples/Ticker_Task/Ticker_Task.ino
@@ -6,12 +6,12 @@ Ticker ticker1, ticker2;
 
 void m_ticker1_handle(void)
 {
-    Serial1.println("handle1 ");    
+    Serial.println("handle1 ");
 }
 
 void m_ticker2_handle(void)
 {
-    Serial1.println("handle2 ");    
+    Serial.println("handle2 ");
 }
 
 void setup() {
@@ -20,8 +20,8 @@ void setup() {
     ticker2.attach_us(m_ticker2_handle, 200000);
 
     pinMode(D13, OUTPUT);
-    Serial1.begin(115200);
-    Serial1.println("Ticker Task Test ");    
+    Serial.begin(115200);
+    Serial.println("Ticker Task Test ");
 }
 
 void loop() {

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/platform.txt
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/platform.txt
@@ -14,11 +14,11 @@ compiler.S.flags=-mcpu=cortex-m0 -mthumb
 
 # Compile c files options
 compiler.c.cmd=arm-none-eabi-gcc
-compiler.c.flags=-c -g -Os -w -std=gnu99 -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections -fomit-frame-pointer -nostdlib --param max-inline-insns-single=500 -DBLE_STACK_SUPPORT_REQD -DDEBUG_NRF_USER -DNRF51 -DTARGET_NRF51822 -DTARGET_M0 -DTARGET_CORTEX_M -DTARGET_NORDIC -DTARGET_NRF51822_MKIT -DTARGET_MCU_NRF51822 -DTOOLCHAIN_GCC_ARM -DTOOLCHAIN_GCC -D__CORTEX_M0 -DARM_MATH_CM0 -DMBED_BUILD_TIMESTAMP=1435023129.97 -D__MBED__=1
+compiler.c.flags=-c -g -Os -w -std=gnu99 -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections -fomit-frame-pointer -nostdlib --param max-inline-insns-single=500 -DBLE_STACK_SUPPORT_REQD -DDEBUG_NRF_USER -DNRF51 -DNRF51_S130 -DTARGET_NRF51822 -DTARGET_M0 -DTARGET_CORTEX_M -DTARGET_NORDIC -DTARGET_NRF51822_MKIT -DTARGET_MCU_NRF51822 -DTOOLCHAIN_GCC_ARM -DTOOLCHAIN_GCC -D__CORTEX_M0 -DARM_MATH_CM0 -DMBED_BUILD_TIMESTAMP=1435023129.97 -D__MBED__=1
 
 # Compile cpp files options
 compiler.cpp.cmd=arm-none-eabi-g++
-compiler.cpp.flags=-c -g -Os -w -std=gnu++98 -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections -fomit-frame-pointer -nostdlib --param max-inline-insns-single=500 -fno-rtti -DBLE_STACK_SUPPORT_REQD -DDEBUG_NRF_USER -DNRF51 -DTARGET_NRF51822 -DTARGET_M0 -DTARGET_CORTEX_M -DTARGET_NORDIC -DTARGET_NRF51822_MKIT -DTARGET_MCU_NRF51822 -DTOOLCHAIN_GCC_ARM -DTOOLCHAIN_GCC -D__CORTEX_M0 -DARM_MATH_CM0 -DMBED_BUILD_TIMESTAMP=1435023129.97 -D__MBED__=1
+compiler.cpp.flags=-c -g -Os -w -std=gnu++98 -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections -fomit-frame-pointer -nostdlib --param max-inline-insns-single=500 -fno-rtti -DBLE_STACK_SUPPORT_REQD -DDEBUG_NRF_USER -DNRF51 -DNRF51_S130 -DTARGET_NRF51822 -DTARGET_M0 -DTARGET_CORTEX_M -DTARGET_NORDIC -DTARGET_NRF51822_MKIT -DTARGET_MCU_NRF51822 -DTOOLCHAIN_GCC_ARM -DTOOLCHAIN_GCC -D__CORTEX_M0 -DARM_MATH_CM0 -DMBED_BUILD_TIMESTAMP=1435023129.97 -D__MBED__=1
 
 # Create archives options
 compiler.ar.cmd=arm-none-eabi-ar

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/platform.txt
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/platform.txt
@@ -1,6 +1,6 @@
 
 # RBL_nRF51822 compile variables
-# ------------------------- 
+# -------------------------
 
 name=RedBearLab Boards
 
@@ -10,15 +10,15 @@ compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
 
 # Compile s files options
 compiler.S.cmd=arm-none-eabi-as
-compiler.S.flags=-mcpu=cortex-m0 -mthumb 
+compiler.S.flags=-mcpu=cortex-m0 -mthumb
 
 # Compile c files options
 compiler.c.cmd=arm-none-eabi-gcc
-compiler.c.flags=-c -g -Os -w -std=gnu99 -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections -fomit-frame-pointer -nostdlib --param max-inline-insns-single=500 -DBLE_STACK_SUPPORT_REQD -DDEBUG_NRF_USER -DNRF51 -DTARGET_NRF51822 -DTARGET_M0 -DTARGET_CORTEX_M -DTARGET_NORDIC -DTARGET_NRF51822_MKIT -DTARGET_MCU_NRF51822 -DTOOLCHAIN_GCC_ARM -DTOOLCHAIN_GCC -D__CORTEX_M0 -DARM_MATH_CM0 -DMBED_BUILD_TIMESTAMP=1435023129.97 -D__MBED__=1 
+compiler.c.flags=-c -g -Os -w -std=gnu99 -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections -fomit-frame-pointer -nostdlib --param max-inline-insns-single=500 -DBLE_STACK_SUPPORT_REQD -DDEBUG_NRF_USER -DNRF51 -DTARGET_NRF51822 -DTARGET_M0 -DTARGET_CORTEX_M -DTARGET_NORDIC -DTARGET_NRF51822_MKIT -DTARGET_MCU_NRF51822 -DTOOLCHAIN_GCC_ARM -DTOOLCHAIN_GCC -D__CORTEX_M0 -DARM_MATH_CM0 -DMBED_BUILD_TIMESTAMP=1435023129.97 -D__MBED__=1
 
 # Compile cpp files options
 compiler.cpp.cmd=arm-none-eabi-g++
-compiler.cpp.flags=-c -g -Os -w -std=gnu++98 -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections -fomit-frame-pointer -nostdlib --param max-inline-insns-single=500 -fno-rtti -DBLE_STACK_SUPPORT_REQD -DDEBUG_NRF_USER -DNRF51 -DTARGET_NRF51822 -DTARGET_M0 -DTARGET_CORTEX_M -DTARGET_NORDIC -DTARGET_NRF51822_MKIT -DTARGET_MCU_NRF51822 -DTOOLCHAIN_GCC_ARM -DTOOLCHAIN_GCC -D__CORTEX_M0 -DARM_MATH_CM0 -DMBED_BUILD_TIMESTAMP=1435023129.97 -D__MBED__=1 
+compiler.cpp.flags=-c -g -Os -w -std=gnu++98 -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections -fomit-frame-pointer -nostdlib --param max-inline-insns-single=500 -fno-rtti -DBLE_STACK_SUPPORT_REQD -DDEBUG_NRF_USER -DNRF51 -DTARGET_NRF51822 -DTARGET_M0 -DTARGET_CORTEX_M -DTARGET_NORDIC -DTARGET_NRF51822_MKIT -DTARGET_MCU_NRF51822 -DTOOLCHAIN_GCC_ARM -DTOOLCHAIN_GCC -D__CORTEX_M0 -DARM_MATH_CM0 -DMBED_BUILD_TIMESTAMP=1435023129.97 -D__MBED__=1
 
 # Create archives options
 compiler.ar.cmd=arm-none-eabi-ar
@@ -26,8 +26,8 @@ compiler.ar.flags=rcs
 
 # Combine to create elf file options
 compiler.c.elf.cmd=arm-none-eabi-gcc
-compiler.c.elf.flags=-mcpu=cortex-m0 -mthumb 
-compiler.ldflags=--specs=nano.specs 
+compiler.c.elf.flags=-mcpu=cortex-m0 -mthumb
+compiler.ldflags=--specs=nano.specs
 
 # Create bin file options
 compiler.elf2bin.cmd=arm-none-eabi-objcopy
@@ -35,7 +35,7 @@ compiler.elf2bin.flags=-O binary
 
 # Create hex file options
 compiler.elf2hex.cmd=arm-none-eabi-objcopy
-compiler.elf2hex.flags=-O ihex  -I binary 
+compiler.elf2hex.flags=-O ihex  -I binary
 compiler.elf2hex.flagx=-O ihex
 
 # Calculate hex size options
@@ -52,7 +52,7 @@ recipe.S.o.pattern="{compiler.path}{compiler.S.cmd}" {compiler.S.flags} "{source
 recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} -mcpu={build.mcu} -DF_CPU={build.f_cpu} -D{software}={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {build.extra_flags} {build.mbed_api_include} {build.nRF51822_api_include} {build.ble_api_include} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile c++ files
-recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -mcpu={build.mcu} -DF_CPU={build.f_cpu} -D{software}={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {build.extra_flags} {build.mbed_api_include} {build.nRF51822_api_include} {build.ble_api_include} {includes} "{source_file}" -o "{object_file}" 
+recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -mcpu={build.mcu} -DF_CPU={build.f_cpu} -D{software}={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {build.extra_flags} {build.mbed_api_include} {build.nRF51822_api_include} {build.ble_api_include} {includes} "{source_file}" -o "{object_file}"
 
 ## Create archives
 #recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} "{archive_file_path}" "{object_file}"
@@ -65,8 +65,8 @@ recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" -mcpu={build.mcu}
 recipe.objcopy.eep.pattern="{compiler.path}{compiler.elf2bin.cmd}" {compiler.elf2bin.flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.bin"
 
 ## Create hex
-recipe.objcopy.hex1.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf2hex.flagx} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}_OTA.hex" 
-recipe.objcopy.hex2.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf2hex.flags} "{build.path}/{build.project_name}.bin" "{build.path}/{build.project_name}.hex" 
+recipe.objcopy.hex1.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf2hex.flagx} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}_OTA.hex"
+recipe.objcopy.hex2.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf2hex.flags} "{build.path}/{build.project_name}.bin" "{build.path}/{build.project_name}.hex"
 
 ## Save hex
 recipe.output.tmp_file={build.project_name}_OTA.hex


### PR DESCRIPTION
Includes:
- Removing `Serial.h` mbed include to allow `Serial1` to be renamed to `Serial`. (#35)
- Moving `BLE_API.h` include in `Arduino.h` to Sketch level.
- Updating all examples for the above changes.
- Misc. trailing whitespace removal.
- Add new `NRF51_S130` define to distinguish building for S130 vs S110

I've made sure all of the examples build with the changes, but haven't run all of them on a board.
