### PR TITLE
Fix shiftOut() not generating clock correctly

### DIFF
--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/wiring_shift_pulseIn.cpp
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/wiring_shift_pulseIn.cpp
@@ -34,9 +34,10 @@ void shiftOut(uint32_t DataPin, uint32_t ClockPin, BitOrder Order, uint8_t value
         else {
             digitalWrite(DataPin, !!(value&(1<<(7-index))));
         }
+        
+        digitalWrite(ClockPin, HIGH);
+        digitalWrite(ClockPin, LOW);
     }
-    digitalWrite(ClockPin, HIGH);
-    digitalWrite(ClockPin, LOW);
 }
 
 


### PR DESCRIPTION
shiftOut() only generated a clock after all data had been transmitted. Not for each singular bit

e.g.
8 bits of data
only 1 clock pulse
