### PR TITLE
Fix `Wire::endTransmission()`

### DIFF
--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/Wire/Wire.cpp
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/libraries/Wire/Wire.cpp
@@ -102,7 +102,7 @@ int8_t TwoWire::endTransmission( uint8_t stop)
 {
     int8_t result=0;
 
-    result = i2c_write(&i2c, Transfer_Addr, (const char *)TX_Buffer, TX_BufferHead, stop);
+    i2c_write(&i2c, Transfer_Addr, (const char *)TX_Buffer, TX_BufferHead, stop);
 
     TX_BufferHead = 0;
     twi_status = MASTER_IDLE;


### PR DESCRIPTION
The current impementation returns the number of bytes written. However, according to [Arduino Documentation](https://www.arduino.cc/en/Reference/WireEndTransmission), it should return 0 on success.