### PR TITLE
Resolve conflict with POSIX errno

### DIFF
--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/btle/btle.cpp
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/btle/btle.cpp
@@ -77,7 +77,7 @@ static uint32_t eventHandler()
     return NRF_SUCCESS;
 }
 
-error_t btle_init(void)
+nrf_error_t btle_init(void)
 {
     nrf_clock_lfclksrc_t clockSource;
     if (NRF_CLOCK->LFCLKSRC & (CLOCK_LFCLKSRC_SRC_Xtal << CLOCK_LFCLKSRC_SRC_Pos)) {

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/btle/btle.h
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/btle/btle.h
@@ -26,7 +26,7 @@ extern "C" {
 #include "ble_srv_common.h"
 #include "ble.h"
 
-error_t     btle_init(void);
+nrf_error_t     btle_init(void);
 
 #ifdef __cplusplus
 }

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/btle/btle_advertising.cpp
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/btle/btle_advertising.cpp
@@ -25,7 +25,7 @@
     @returns
 */
 /**************************************************************************/
-error_t btle_advertising_start(void)
+nrf_error_t btle_advertising_start(void)
 {
     ble_gap_adv_params_t adv_para = {0};
 

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/btle/btle_advertising.h
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/btle/btle_advertising.h
@@ -19,6 +19,6 @@
 
 #include "common/common.h"
 
-error_t btle_advertising_start(void);
+nrf_error_t btle_advertising_start(void);
 
 #endif // ifndef _BTLE_ADVERTISING_H_

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/btle/btle_gap.cpp
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/btle/btle_gap.cpp
@@ -30,7 +30,7 @@ static void   error_callback(uint32_t nrf_error);
     @returns
 */
 /**************************************************************************/
-error_t btle_gap_init(void)
+nrf_error_t btle_gap_init(void)
 {
     ble_gap_conn_params_t gap_conn_params = {0};
 

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/btle/btle_gap.h
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/btle/btle_gap.h
@@ -19,6 +19,6 @@
 
 #include "common/common.h"
 
-error_t btle_gap_init(void);
+nrf_error_t btle_gap_init(void);
 
 #endif // ifndef _BTLE_GAP_H_

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/btle/custom/custom_helper.cpp
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/btle/custom/custom_helper.cpp
@@ -162,7 +162,7 @@ uint8_t custom_add_uuid_base(uint8_t const *const p_uuid_base)
 
 */
 /**************************************************************************/
-error_t custom_decode_uuid_base(uint8_t const *const p_uuid_base,
+nrf_error_t custom_decode_uuid_base(uint8_t const *const p_uuid_base,
                                 ble_uuid_t          *p_uuid)
 {
     UUID::LongUUIDBytes_t uuid_base_le;
@@ -197,7 +197,7 @@ error_t custom_decode_uuid_base(uint8_t const *const p_uuid_base,
     @retval     ERROR_NONE        Everything executed normally
 */
 /**************************************************************************/
-error_t custom_add_in_characteristic(uint16_t                  service_handle,
+nrf_error_t custom_add_in_characteristic(uint16_t                  service_handle,
                                      ble_uuid_t               *p_uuid,
                                      uint8_t                   properties,
                                      SecurityManager::SecurityMode_t       requiredSecurity,
@@ -326,7 +326,7 @@ error_t custom_add_in_characteristic(uint16_t                  service_handle,
     @retval     ERROR_NONE        Everything executed normally
 */
 /**************************************************************************/
-error_t custom_add_in_descriptor(uint16_t    char_handle,
+nrf_error_t custom_add_in_descriptor(uint16_t    char_handle,
                                  ble_uuid_t *p_uuid,
                                  uint8_t    *p_data,
                                  uint16_t    length,

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/btle/custom/custom_helper.h
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/btle/custom/custom_helper.h
@@ -27,11 +27,11 @@ extern "C" {
 #endif
 
 uint8_t custom_add_uuid_base(uint8_t const *const p_uuid_base);
-error_t custom_decode_uuid(uint8_t const *const p_uuid_base,
+nrf_error_t custom_decode_uuid(uint8_t const *const p_uuid_base,
                            ble_uuid_t          *p_uuid);
 ble_uuid_t custom_convert_to_nordic_uuid(const UUID &uuid);
 
-error_t custom_add_in_characteristic(uint16_t                  service_handle,
+nrf_error_t custom_add_in_characteristic(uint16_t                  service_handle,
                                      ble_uuid_t               *p_uuid,
                                      uint8_t                   properties,
                                      SecurityManager::SecurityMode_t requiredSecurity,
@@ -45,7 +45,7 @@ error_t custom_add_in_characteristic(uint16_t                  service_handle,
                                      bool                      writeAuthorization,
                                      ble_gatts_char_handles_t *p_char_handle);
 
-error_t custom_add_in_descriptor(uint16_t                      char_handle,
+nrf_error_t custom_add_in_descriptor(uint16_t                      char_handle,
                                      ble_uuid_t               *p_uuid,
                                      uint8_t                  *p_data,
                                      uint16_t                  length,

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/common/assertion.h
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/common/assertion.h
@@ -108,18 +108,18 @@ static inline void debugger_breakpoint(void)
 #define ASSERT_DEFINE(...) ASSERT_DEFINE_WITH_HANDLER(ASSERT_ERROR_HANDLER, NULL, __VA_ARGS__)
 
 //--------------------------------------------------------------------+
-// error_t Status Assert TODO use ASSERT_DEFINE
+// nrf_error_t Status Assert TODO use ASSERT_DEFINE
 //--------------------------------------------------------------------+
 #define ASSERT_STATUS_MESSAGE(sts, message) \
-    ASSERT_DEFINE(error_t status = (error_t)(sts),\
+    ASSERT_DEFINE(nrf_error_t status = (nrf_error_t)(sts),\
                   ERROR_NONE == status, status, "%s: %s", ErrorStr[status], message)
 
 #define ASSERT_STATUS(sts) \
-    ASSERT_DEFINE(error_t status = (error_t)(sts),\
+    ASSERT_DEFINE(nrf_error_t status = (nrf_error_t)(sts),\
                   ERROR_NONE == status, status, "error = %d", status)
 
 #define ASSERT_STATUS_RET_VOID(sts) \
-    ASSERT_DEFINE(error_t status = (error_t)(sts),\
+    ASSERT_DEFINE(nrf_error_t status = (nrf_error_t)(sts),\
                   ERROR_NONE == status, (void) 0, "error = %d", status)
 
 //--------------------------------------------------------------------+

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/common/ble_error.h
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/common/ble_error.h
@@ -140,7 +140,7 @@ typedef enum
   ERROR_BLEGATTS_INVALID_ATTR_TYPE              = 0x3400 , /**< Invalid attribute type. */
   ERROR_BLEGATTS_SYS_ATTR_MISSING               = 0x3401 , /**< System Attributes missing. */
 
-}error_t;
+}nrf_error_t;
 
 #ifdef __cplusplus
  }

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/nRF5xGattServer.cpp
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/cores/RBL_nRF51822/ble-nrf51822-master/source/nRF5xGattServer.cpp
@@ -244,7 +244,7 @@ ble_error_t nRF5xGattServer::write(Gap::Handle_t connectionHandle, GattAttribute
             nRF5xGap &gap = (nRF5xGap &) nRF5xn::Instance(BLE::DEFAULT_INSTANCE).getGap();
             connectionHandle = gap.getConnectionHandle();
         }
-        error_t error = (error_t) sd_ble_gatts_hvx(connectionHandle, &hvx_params);
+        nrf_error_t error = (nrf_error_t) sd_ble_gatts_hvx(connectionHandle, &hvx_params);
         if (error != ERROR_NONE) {
             switch (error) {
                 case ERROR_BLE_NO_TX_BUFFERS: /*  Notifications consume application buffers. The return value can be used for resending notifications. */


### PR DESCRIPTION
This patch is hot-fixing type conflict between
error_t in ble_error.h and POSIX errno.h
The effective boundary of error_t defined in ble_error.h
is restricted to nrf51822 code base so this patch is changing
the definition name of error_t to nrf_error_t.

Signed-off-by: Dongsoo Kim <dongsoo.kim@gmail.com>