### PR TITLE
added LED_BUILTIN #define to pins_arduino.h

### DIFF
--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/variants/BLE_Nano/pins_arduino.h
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/variants/BLE_Nano/pins_arduino.h
@@ -45,6 +45,7 @@
 #define TWI_SCL SCL
 
 #define LED D13
+#define LED_BUILTIN D13
 
 #endif
 

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/variants/BLE_Nano_32KB/pins_arduino.h
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/variants/BLE_Nano_32KB/pins_arduino.h
@@ -45,6 +45,7 @@
 #define TWI_SCL SCL
 
 #define LED D13
+#define LED_BUILTIN D13
 
 #endif
 

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/variants/RBL_nRF51822/pins_arduino.h
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/variants/RBL_nRF51822/pins_arduino.h
@@ -56,6 +56,7 @@
 #define TWI_SCL SCL1
 
 #define LED D13
+#define LED_BUILTIN D13
 
 #endif
 

--- a/arduino-1.6.x/hardware/RBL/RBL_nRF51822/variants/RBL_nRF51822_32KB/pins_arduino.h
+++ b/arduino-1.6.x/hardware/RBL/RBL_nRF51822/variants/RBL_nRF51822_32KB/pins_arduino.h
@@ -56,6 +56,7 @@
 #define TWI_SCL SCL1
 
 #define LED D13
+#define LED_BUILTIN D13
 
 #endif
 


### PR DESCRIPTION
This means the ble nanos should now compile out of the box with the standard Arduino Blink sketch (and conform to the Arduino way of defining LED)